### PR TITLE
Use static Sentry instance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,6 @@ apply plugin: "org.junit.platform.gradle.plugin"
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-jdk8', version: '0.17'
-    compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: '0.17'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.0-M4'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.0-M4'
 }
@@ -47,7 +45,6 @@ repositories {
 dependencies {
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jre8', version: '$kotlin_version'
     compile group: 'org.jetbrains.ktor', name: 'ktor-core', version: '0.4.0'
-    compile group: 'org.jetbrains.ktor', name: 'ktor-netty', version: '0.4.0'
     compile group: 'io.sentry', name: 'sentry-logback', version: '1.3.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ junitPlatform {
 
 repositories {
     jcenter()
-    maven { url "https://dl.bintray.com/kotlin/kotlinx" }
     maven { url "https://dl.bintray.com/kotlin/ktor" }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ repositories {
 dependencies {
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jre8', version: '$kotlin_version'
     compile group: 'org.jetbrains.ktor', name: 'ktor-core', version: '0.4.0'
-    compile group: 'io.sentry', name: 'sentry-logback', version: '1.3.0'
+    compile group: 'io.sentry', name: 'sentry', version: '1.4.0'
 }
 
 compileKotlin {

--- a/src/main/kotlin/se/zensum/ktorSentryFeature/sentryFeature.kt
+++ b/src/main/kotlin/se/zensum/ktorSentryFeature/sentryFeature.kt
@@ -12,7 +12,7 @@ class SentryFeature(configuration: Configuration) {
     val sentryClient = Sentry.init(configuration.dsn).apply {environment = configuration.appEnv }
 
     class Configuration {
-        var dsn: String? = System.getenv()["SENTRY_DSN"]
+        var dsn: String? = null
         var appEnv: String = "n/a"
     }
 

--- a/src/main/kotlin/se/zensum/ktorSentryFeature/sentryFeature.kt
+++ b/src/main/kotlin/se/zensum/ktorSentryFeature/sentryFeature.kt
@@ -1,26 +1,39 @@
 package se.zensum.ktorSentry
 
 import io.sentry.Sentry
-import org.jetbrains.ktor.application.ApplicationCall
+import io.sentry.SentryClient
 import org.jetbrains.ktor.application.ApplicationCallPipeline
 import org.jetbrains.ktor.application.ApplicationFeature
 import org.jetbrains.ktor.pipeline.PipelineContext
 import org.jetbrains.ktor.util.AttributeKey
 
-class SentryFeature(configuration: Configuration) {
+private typealias CustomizeFn = SentryClient.() -> Unit
 
-    val sentryClient = Sentry.init(configuration.dsn).apply {environment = configuration.appEnv }
+class SentryFeature(configuration: Configuration) {
 
     class Configuration {
         var dsn: String? = null
-        var appEnv: String = "n/a"
+        var appEnv: String? = null
+        var customizeFn: CustomizeFn? = null
+        fun customize(fn: CustomizeFn) { customizeFn = fn }
+
+        internal fun initClient() {
+            // If the user has specified a
+            if (dsn != null) {
+                Sentry.init(dsn)
+            }
+            if (appEnv != null) {
+                Sentry.getStoredClient().environment = appEnv
+            }
+            customizeFn?.invoke(Sentry.getStoredClient())
+        }
     }
 
     suspend fun intercept(context: PipelineContext<Unit>) {
-        try{
+        try {
             context.proceed()
-        }catch (e: Exception){
-            sentryClient.sendException(e)
+        } catch (e: Exception) {
+            Sentry.capture(e)
             throw e
         }
     }
@@ -28,7 +41,10 @@ class SentryFeature(configuration: Configuration) {
     companion object Feature : ApplicationFeature<ApplicationCallPipeline, Configuration, SentryFeature> {
         override val key = AttributeKey<SentryFeature>("SentryFeature")
         override fun install(pipeline: ApplicationCallPipeline, configure: Configuration.() -> Unit): SentryFeature {
-            val result = SentryFeature(Configuration().apply(configure))
+            val cfg = Configuration().apply(configure)
+            cfg.initClient()
+            val result = SentryFeature(cfg)
+
             pipeline.intercept(ApplicationCallPipeline.Call) {
                 result.intercept(this)
             }

--- a/src/main/kotlin/se/zensum/ktorSentryFeature/sentryFeature.kt
+++ b/src/main/kotlin/se/zensum/ktorSentryFeature/sentryFeature.kt
@@ -18,7 +18,7 @@ private inline fun <T> sentryWrap(fn: () -> T) = try {
     Sentry.clearContext()
 }
 
-class SentryFeature(configuration: Configuration) {
+class SentryFeature private constructor(){
 
     class Configuration {
         var dsn: String? = null
@@ -47,7 +47,7 @@ class SentryFeature(configuration: Configuration) {
         override fun install(pipeline: ApplicationCallPipeline, configure: Configuration.() -> Unit): SentryFeature {
             val cfg = Configuration().apply(configure)
             cfg.initClient()
-            val result = SentryFeature(cfg)
+            val result = SentryFeature()
 
             pipeline.intercept(ApplicationCallPipeline.Call) {
                 result.intercept(this)

--- a/src/main/kotlin/se/zensum/ktorSentryFeature/sentryFeature.kt
+++ b/src/main/kotlin/se/zensum/ktorSentryFeature/sentryFeature.kt
@@ -18,7 +18,7 @@ private inline fun <T> sentryWrap(fn: () -> T) = try {
     Sentry.clearContext()
 }
 
-class SentryFeature private constructor(){
+class SentryFeature private constructor() {
 
     class Configuration {
         var dsn: String? = null


### PR DESCRIPTION
Using the static instance of Sentry makes sense because it enables the user to easily add Breadcrumbs and static data